### PR TITLE
fix typo  - change "bro_tunnel" to "bro_tunnels"

### DIFF
--- a/configfiles/1118_preprocess_bro_tunnel.conf
+++ b/configfiles/1118_preprocess_bro_tunnel.conf
@@ -1,11 +1,11 @@
 # Author: Justin Henderson
 #         SANS Instructor and author of SANS SEC555: SIEM and Tactical Analytics
-# Email: justin@hasecuritysolution.com
-# Last Update: 12/9/2016
+# Updated by: Wes Lambert
+# Last Update: 5/13/2017
 #
 # This conf file is based on accepting logs for tunnel.log from Bro systems
 filter {
-  if [type] == "bro_tunnel" {
+  if [type] == "bro_tunnels" {
     # This is the initial parsing of the log
     csv {
       columns => ["timestamp","uid","source_ip","source_port","destination_ip","destination_port","tunnel_type","action"]


### PR DESCRIPTION
Previously not parsing correctly.  Changed if == "bro_tunnel" to if == "bro_tunnels".