### PR TITLE
update grok to parse alerts w/o src/dst ports

### DIFF
--- a/configfiles/1033_preprocess_snort.conf
+++ b/configfiles/1033_preprocess_snort.conf
@@ -1,13 +1,13 @@
 # Author: Justin Henderson
 #         SANS Instructor and author of SANS SEC555: SIEM and Tactical Analytics
-# Email: justin@hasecuritysolution.com
-# Last Update: 12/9/2016
+# Updated by: Wes Lambert
+# Last Update: 5/13/2017
 
 filter {
   if [type] == "snort" {
     # This is the initial parsing of the log
     grok {
-      match => { "message" => "\[%{INT:gid}:%{INT:sid}:%{INT:rev}\]\s%{DATA:alert}\[Classification:\s+%{DATA:classification}\]\s+\[Priority:\s+%{INT:priority}\]:\s+{%{DATA:protocol}}\s+%{IPV4:source_ip}:%{INT:source_port}\s+->\s+%{IPV4:destination_ip}:%{INT:destination_port}%{GREEDYDATA:message}"}
+      match => ["message", "\[%{INT:gid}:%{INT:sid}:%{INT:rev}\]\s%{DATA:alert}\[Classification:\s+%{DATA:classification}\]\s+\[Priority:\s+%{INT:priority}\]:\s+{%{DATA:protocol}}\s+%{IPV4:source_ip}:%{INT:source_port}\s+->\s+%{IPV4:destination_ip}:%{INT:destination_port}%{GREEDYDATA:message}", "message", "\[%{INT:gid}:%{INT:sid}:%{INT:rev}\]\s%{DATA:alert}\[Classification:\s+%{DATA:classification}\]\s+\[Priority:\s+%{INT:priority}\]:\s+{%{DATA:protocol}}\s%{IPV4:source_ip}\s+->\s+%{IPV4:destination_ip}"]
     }
 	
 	# This will attempt to do a geoip lookup against the SrcIP


### PR DESCRIPTION
Previously was not parsing alerts without source/destination ports.

Ex. GPL ICMP_INFO PING BSDtype [Classification: Misc activity] [Priority: 3]: {GRE} 172.27.1.66 -> 66.59.109.137
