### PR TITLE
Configure persistent queue(s)

### DIFF
--- a/logstash/logstash.yml
+++ b/logstash/logstash.yml
@@ -1,0 +1,3 @@
+path.config: /usr/share/logstash/pipeline
+queue.type: persisted
+queue.max_bytes: 1gb

--- a/securityonion_elsa2elastic.sh.new
+++ b/securityonion_elsa2elastic.sh.new
@@ -209,9 +209,12 @@ chown -R 1000:1000 /nsm/es
 echo "Done!"
 
 header "Configuring Logstash"
+mkdir -p /nsm/logstash
+chown -R 1000:1000 /nsm/logstash
 mkdir -p /etc/logstash/conf.d/
 cp -rf elk-test/configfiles/*.conf /etc/logstash/conf.d/
 cp elk-test/logstash/logstash-template.json /etc/logstash/
+cp elk-test/logstash/logstash.yml /etc/logstash/
 cp -rf elk-test/dictionaries /lib/
 cp -rf elk-test/grok-patterns /lib/
 echo "Done!"
@@ -224,7 +227,7 @@ echo "Done!"
 
 header "Starting Elastic Stack"
 docker run -d --name=so-elasticsearch -p 9200:9200 -e "http.host=0.0.0.0" -e "transport.host=127.0.0.1" -e "bootstrap_memory_lock=true" --ulimit memlock=-1:-1 -v /nsm/es:/usr/share/elasticsearch/data $DOCKERHUB/so-elasticsearch
-docker run -d --name=so-logstash --link=so-elasticsearch:elasticsearch -v /etc/logstash/logstash-template.json:/logstash-template.json:ro -v /etc/logstash/conf.d:/usr/share/logstash/pipeline/:ro -v /lib/dictionaries:/lib/dictionaries:ro -v /nsm/import:/nsm/import:ro -p 6050:6050 -p 6051:6051 -p 6052:6052 -p 6053:6053 $DOCKERHUB/so-logstash
+docker run -d --name=so-logstash --link=so-elasticsearch:elasticsearch -v /etc/logstash/logstash.yml:/opt/logstash/config/logstash.yml:ro -v /etc/logstash/logstash-template.json:/logstash-template.json:ro -v /etc/logstash/conf.d:/usr/share/logstash/pipeline/:ro -v /nsm/logstash:/usr/share/logstash/data/ -v /lib/dictionaries:/lib/dictionaries:ro -v /nsm/import:/nsm/import:ro -p 6050:6050 -p 6051:6051 -p 6052:6052 -p 6053:6053 $DOCKERHUB/so-logstash
 docker run -d --name=so-kibana -p 5601:5601 --link=so-elasticsearch:elasticsearch -e "KIBANA_DEFAULTAPPID=dashboard/94b52620-342a-11e7-9d52-4f090484f59e" $DOCKERHUB/so-kibana
 echo "Done!"
 


### PR DESCRIPTION
Configure logstash to use persistent queues configured at 1GB.