### PR TITLE
Convert to int in 6500_ossec.conf

### DIFF
--- a/configfiles/1034_preprocess_syslog.conf
+++ b/configfiles/1034_preprocess_syslog.conf
@@ -10,7 +10,7 @@ filter {
     #  drop { }
     #}
 	mutate {
-		convert => [ "status_code", "integer" ]
+		#convert => [ "status_code", "integer" ]
 	}
   }  
 }

--- a/configfiles/6002_syslog.conf
+++ b/configfiles/6002_syslog.conf
@@ -4,7 +4,7 @@
 filter {
   if "syslog" in [tags] {
 	mutate {
-      		convert => [ "status_code", "integer" ]
+		#convert => [ "status_code", "integer" ]
 	  #add_tag => [ "conf_file_6002"]
 	}
   }

--- a/configfiles/6500_ossec.conf
+++ b/configfiles/6500_ossec.conf
@@ -60,7 +60,10 @@ filter {
   # OSSEC Archive Logs
   if [type] == "ossec_archive" {
       grok {
-      match => ["message",'%{YEAR:year} %{SYSLOGTIMESTAMP:timestamp} %{DATA:location} %{IP:source_ip} - %{DATA:user} \[%{DATA:request_timestamp}] "%{DATA:method} %{DATA:requested_resource} %{DATA:protocol}\/%{DATA:protocol_version}" %{NONNEGINT:status_code} %{NONNEGINT:object_size} "%{DATA:referrer}" "%{DATA:user_agent}"',"message","%{YEAR:year} %{SYSLOGTIMESTAMP:timestamp} %{DATA:location} %{SYSLOGTIMESTAMP:ossec_timestamp} %{DATA:host} %{DATA:process}\[%{NONNEGINT:pid}]: \(%{DATA:user}\) CMD \(%{DATA:command}\)","message", "%{YEAR:year} %{SYSLOGTIMESTAMP:timestamp} %{DATA:location} %{GREEDYDATA:details}","message","%{YEAR:year} %{SYSLOGTIMESTAMP:timestamp} %{DATA:location} %{SYSLOGTIMESTAMP:ossec_timestamp} %{DATA:ossec_host} %{DATA:process}\[%{NONNEGINT:pid}]: %{GREEDYDATA:details}"]
+      match => ["message",'%{YEAR:year} %{SYSLOGTIMESTAMP:timestamp} %{DATA:location} %{IP:source_ip} - %{DATA:user} \[%{DATA:request_timestamp}] "%{DATA:method} %{DATA:requested_resource} %{DATA:protocol}\/%{DATA:protocol_version}" %{NONNEGINT:status_code} %{NONNEGINT:object_size} "%{DATA:referrer}" "%{DATA:user_agent}"',
+		"message","%{YEAR:year} %{SYSLOGTIMESTAMP:timestamp} %{DATA:location} %{SYSLOGTIMESTAMP:ossec_timestamp} %{DATA:host} %{DATA:process}\[%{NONNEGINT:pid}]: \(%{DATA:user}\) CMD \(%{DATA:command}\)",
+		"message", "%{YEAR:year} %{SYSLOGTIMESTAMP:timestamp} %{DATA:location} %{GREEDYDATA:details}","message","%{YEAR:year} %{SYSLOGTIMESTAMP:timestamp} %{DATA:location} %{SYSLOGTIMESTAMP:ossec_timestamp} %{DATA:ossec_host} %{DATA:process}\[%{NONNEGINT:pid}]: %{GREEDYDATA:details}",
+		"message","%{DATA:age} %{DATA:type} %{DATA} '%{DATA:value}'"]
       remove_field => [ "ossec_timestamp" ]
       }
       mutate {

--- a/configfiles/6500_ossec.conf
+++ b/configfiles/6500_ossec.conf
@@ -63,6 +63,9 @@ filter {
       match => ["message",'%{YEAR:year} %{SYSLOGTIMESTAMP:timestamp} %{DATA:location} %{IP:source_ip} - %{DATA:user} \[%{DATA:request_timestamp}] "%{DATA:method} %{DATA:requested_resource} %{DATA:protocol}\/%{DATA:protocol_version}" %{NONNEGINT:status_code} %{NONNEGINT:object_size} "%{DATA:referrer}" "%{DATA:user_agent}"',"message","%{YEAR:year} %{SYSLOGTIMESTAMP:timestamp} %{DATA:location} %{SYSLOGTIMESTAMP:ossec_timestamp} %{DATA:host} %{DATA:process}\[%{NONNEGINT:pid}]: \(%{DATA:user}\) CMD \(%{DATA:command}\)","message", "%{YEAR:year} %{SYSLOGTIMESTAMP:timestamp} %{DATA:location} %{GREEDYDATA:details}","message","%{YEAR:year} %{SYSLOGTIMESTAMP:timestamp} %{DATA:location} %{SYSLOGTIMESTAMP:ossec_timestamp} %{DATA:ossec_host} %{DATA:process}\[%{NONNEGINT:pid}]: %{GREEDYDATA:details}"]
       remove_field => [ "ossec_timestamp" ]
       }
+      mutate {
+              convert => [ "status_code", "integer" ]
+      }
   }
 
 }


### PR DESCRIPTION
-Convert status code to int in 6500_ossec.conf to avoid mapping conflict for field across indices.
-Add basic parsing for md5sum/sha1sum events from 'type:ossec_archive' to prevent _grokparsefailure