### PR TITLE
add rule to ignore Docker file mismatch

### DIFF
--- a/var/ossec/rules/securityonion_rules.xml
+++ b/var/ossec/rules/securityonion_rules.xml
@@ -50,5 +50,11 @@
     <match>/elasticsearch</match>
     <description>Elasticsearch</description>
   </rule>
+  
+  <rule id="111116" level="0">
+    <if_sid>510</if_sid>
+    <match>/var/lib/docker</match>
+    <description>Ignore Docker File Mismatch</description>
+  </rule>
 
 </group>


### PR DESCRIPTION
Ignore alert for rootcheck mismatched files (Docker):

Ex. 
rootcheck Files hidden inside directory '/var/lib/docker/aufs/mnt/d1520c09e4fe0305cb66d2fa166111584dd2b8ce747e08707d9d3c915aee0b3f'. Link count does not match number of files (17,39).

