### PR TITLE
Add Curator

### DIFF
--- a/etc/curator/action/close.yml
+++ b/etc/curator/action/close.yml
@@ -1,0 +1,30 @@
+---
+# Remember, leave a key empty if there is no value.  None will be a string,
+# not a Python "NoneType"
+#
+# Also remember that all examples have 'disable_action' set to True.  If you
+# want to use this action as a template, be sure to set this to False after
+# copying it.
+actions:
+  1:
+    action: close
+    description: >-
+      Close indices older than 2 days (based on index name), for logstash-
+      prefixed indices.
+    options:
+      delete_aliases: False
+      timeout_override:
+      continue_if_exception: False
+      disable_action: False
+    filters:
+    - filtertype: pattern
+      kind: prefix
+      value: logstash-
+      exclude:
+    - filtertype: age
+      source: name
+      direction: older
+      timestring: '%Y.%m.%d'
+      unit: days
+      unit_count: 2
+      exclude:

--- a/etc/curator/action/delete.yml
+++ b/etc/curator/action/delete.yml
@@ -1,0 +1,23 @@
+---
+# Remember, leave a key empty if there is no value.  None will be a string,
+# not a Python "NoneType"
+#
+# Also remember that all examples have 'disable_action' set to True.  If you
+# want to use this action as a template, be sure to set this to False after
+# copying it.
+actions:
+  1:
+    action: delete_indices
+    description: >-
+      Delete indices when $disk_space value (in GB) is exceeded.
+    options:
+      ignore_empty_list: True
+      disable_action: False
+    filters:
+    - filtertype: pattern
+      kind: prefix
+      value: logstash-
+    - filtertype: space
+      source: creation_date
+      use_age: True
+      disk_space: 100

--- a/etc/curator/config/curator.yml
+++ b/etc/curator/config/curator.yml
@@ -1,0 +1,22 @@
+---
+# Remember, leave a key empty if there is no value.  None will be a string,
+# not a Python "NoneType"
+client:
+  hosts:
+    - elasticsearch
+  port: 9200
+  url_prefix:
+  use_ssl: False
+  certificate:
+  client_cert:
+  client_key:
+  ssl_no_validate: False
+  http_auth:
+  timeout: 30
+  master_only: False
+
+logging:
+  loglevel: INFO
+  logfile: '/var/log/curator/curator.log'
+  logformat: default
+  blacklist: ['elasticsearch', 'urllib3']

--- a/etc/curator/cron.d/curator-close
+++ b/etc/curator/cron.d/curator-close
@@ -1,0 +1,7 @@
+#/etc/cron.d/curator-close
+#
+#crontab entry curator 'close' action
+
+SHELL=/bin/sh
+PATH=/usr/local/sbin:/usr/localbin:/sbin:/bin?usr/sbin:/usr/bin
+0 1 * * * root docker exec so-curator curator --config /etc/curator/config/curator.yml --dry-run /etc/curator/action/close.yml > /dev/null 2>&1

--- a/etc/curator/cron.d/curator-delete
+++ b/etc/curator/cron.d/curator-delete
@@ -1,0 +1,7 @@
+#/etc/cron.d/curator-delete
+#
+#crontab entry curator 'delete' action
+
+SHELL=/bin/sh
+PATH=/usr/local/sbin:/usr/localbin:/sbin:/bin?usr/sbin:/usr/bin
+* * * * * root docker exec so-curator curator --config /etc/curator/config/curator.yml --dry-run /etc/curator/action/delete.yml > /dev/null 2>&1

--- a/securityonion_elsa2elastic.sh
+++ b/securityonion_elsa2elastic.sh
@@ -257,7 +257,7 @@ chown -R 1000:1000 /etc/curator
 chown -R 1000:1000 /var/log/curator
 cp -av $REPO/etc/curator/config/* /etc/curator/config/
 cp -av $REPO/etc/curator/action/* /etc/curator/action/
-cp -av $REPO/etc/cron.d/* /etc/cron.d/
+cp -av $REPO/etc/curator/cron.d/* /etc/cron.d/
 echo "Done!"
 
 header "Starting Elastic Stack"

--- a/securityonion_elsa2elastic.sh
+++ b/securityonion_elsa2elastic.sh
@@ -179,6 +179,7 @@ docker pull $DOCKERHUB/so-elasticsearch
 docker pull $DOCKERHUB/so-kibana
 docker pull $DOCKERHUB/so-logstash
 docker pull $DOCKERHUB/so-elastalert
+docker pull $DOCKERHUB/so-curator
 
 echo "Done!"
 
@@ -248,6 +249,17 @@ chown -R 1000:1000 /var/log/elastalert
 cp -av $REPO/etc/elastalert/rules/* /etc/elastalert/rules/
 echo "Done!"
 
+header "Configuring Curator"
+mkdir -p /etc/curator/config
+mkdir -p /etc/curator/action
+mkdir -p /var/log/curator
+chown -R 1000:1000 /etc/curator
+chown -R 1000:1000 /var/log/curator
+cp -av $REPO/etc/curator/config/* /etc/curator/config/
+cp -av $REPO/etc/curator/action/* /etc/curator/action/
+cp -av $REPO/etc/cron.d/* /etc/cron.d/
+echo "Done!"
+
 header "Starting Elastic Stack"
 cat << EOF >> /etc/nsm/securityonion.conf
 
@@ -272,6 +284,10 @@ KIBANA_OPTIONS=""
 #ElastAlert options
 ELASTALERT_ENABLED="yes"
 ELASTALERT_OPTIONS=""
+
+#Curator options
+CURATOR_ENABLED="yes"
+CURATOR_OPTIONS=""
 EOF
 
 chmod +x /usr/sbin/so-elastic-*

--- a/usr/sbin/so-elastic-remove
+++ b/usr/sbin/so-elastic-remove
@@ -12,3 +12,5 @@ echo "Removing existing containers:"
 [ "$LOGSTASH_ENABLED" = "yes" ] && docker rm so-logstash 2>&1 | grep -v "No such container"
 [ "$KIBANA_ENABLED" = "yes" ] && docker rm so-kibana 2>&1 | grep -v "No such container"
 [ "$ELASTALERT_ENABLED" = "yes" ] && docker rm so-elastalert 2>&1 | grep -v "No such container"
+[ "$CURATOR_ENABLED" = "yes" ] && docker rm so-curator 2>&1 | grep -v "No such container"
+

--- a/usr/sbin/so-elastic-start
+++ b/usr/sbin/so-elastic-start
@@ -76,3 +76,13 @@ if [ "$ELASTALERT_ENABLED" = "yes" ]; then
                 $ELASTALERT_OPTIONS \
                 $DOCKERHUB/so-elastalert
 fi
+if [ "$CURATOR_ENABLED" = "yes" ]; then
+        echo -n "so-curator: "
+        docker run --name=so-curator \
+                --detach \
+                --link=so-elasticsearch:elasticsearch \
+                --volume /etc/curator/config/curator.yml:/etc/curator/config/cu
+                --volume /etc/curator/action/:/etc/curator/action:ro \
+                --volume /var/log/curator/:/var/log/curator/ \
+                -it $DOCKERHUB/so-curator
+fi

--- a/usr/sbin/so-elastic-start
+++ b/usr/sbin/so-elastic-start
@@ -81,7 +81,7 @@ if [ "$CURATOR_ENABLED" = "yes" ]; then
         docker run --name=so-curator \
                 --detach \
                 --link=so-elasticsearch:elasticsearch \
-                --volume /etc/curator/config/curator.yml:/etc/curator/config/cu
+                --volume /etc/curator/config/curator.yml:/etc/curator/config/curator.yml:ro \
                 --volume /etc/curator/action/:/etc/curator/action:ro \
                 --volume /var/log/curator/:/var/log/curator/ \
                 -it $DOCKERHUB/so-curator

--- a/usr/sbin/so-elastic-status
+++ b/usr/sbin/so-elastic-status
@@ -5,4 +5,4 @@ if [ "$(id -u)" -ne 0 ]; then
         exit 1
 fi
 
-docker stats so-elasticsearch so-logstash so-kibana so-elastalert $@
+docker stats so-elasticsearch so-logstash so-kibana so-elastalert so-curator $@

--- a/usr/sbin/so-elastic-stop
+++ b/usr/sbin/so-elastic-stop
@@ -12,3 +12,4 @@ echo "Stopping containers:"
 [ "$KIBANA_ENABLED" = "yes" ] && docker stop so-kibana
 [ "$ELASTICSEARCH_ENABLED" = "yes" ] && docker stop so-elasticsearch
 [ "$ELASTALERT_ENABLED" = "yes" ] && docker stop so-elastalert
+[ "$CURATOR_ENABLED" = "yes" ] && docker stop so-curator

--- a/usr/sbin/sostat
+++ b/usr/sbin/sostat
@@ -421,8 +421,8 @@ if [ "$ELASTICSEARCH_ENABLED" = "yes" ]; then
 	ES_RUNNING=$(docker ps | grep so-elasticsearch)
 	LS_RUNNING=$(docker ps | grep so-logstash)
 	KIB_RUNNING=$(docker ps | grep so-kibana)
-	#ELAST_RUNNING=$(docker ps | grep so-elastalert)
-	#CURAT_RUNNING=$(docker ps } grep so-curator)
+	ELAST_RUNNING=$(docker ps | grep so-elastalert)
+	CURAT_RUNNING=$(docker ps } grep so-curator)
 	
 	echo
         header "Elasticsearch"
@@ -470,12 +470,21 @@ if [ "$ELASTICSEARCH_ENABLED" = "yes" ]; then
 	fi
 	header "ElastAlert"
         if [ "$ELASTALERT_ENABLED" = "yes" ]; then
-                if [ "$ELASTALERT_RUNNING" ]; then
+                if [ "$ELAST_RUNNING" ]; then
 			echo && echo "ElastAlert is running."
 			echo
                         docker stats --no-stream so-elastalert
                 else
 			echo && echo -e "ElastAlert is not running.\n\nTry starting it with:\n\n'sudo so-elastic-start'\n OR\n'sudo docker start so-elastalert'\n\n\nIf that does not work, try checking /var/log/elastalert/elastalert_stderr.log for clues."
+                fi
+        fi
+	if [ "$CURATOR_ENABLED" = "yes" ]; then
+                if [ "$CURAT_RUNNING" ]; then
+                        echo && echo "Curator is running."
+                        echo
+                        docker stats --no-stream so-curator
+                else
+                        echo && echo -e "Curator is not running.\n\nTry starting it with:\n\n'sudo so-elastic-start'\n OR\n'sudo docker start so-curator'\n\n\nIf that does not work, try checking /var/log/curator/curator.log for clues."
                 fi
         fi
 fi


### PR DESCRIPTION
Adds Curator with two default actions (close and delete) configured as a dry run, with `--dry-run` in `/etc/cron.d/curator-close` and `/etc/cron.d/curator-delete`.

-Actions are configured/stored in `/etc/curator/action/`
-Config stored in `/etc/curator/config/`
-Log file located in `/var/log/curator/`
