### PR TITLE
Update for freq_server and domain_stats support

### DIFF
--- a/usr/sbin/so-elastic-start
+++ b/usr/sbin/so-elastic-start
@@ -33,6 +33,18 @@ fi
 
 if [ "$LOGSTASH_ENABLED" = "yes" ]; then
 	echo -n "so-logstash: "
+	if [ "$FREQ_SERVER_ENABLED" = "yes" ]; then
+		cp -f /etc/logstash/optional/*_postprocess_freq_analysis_*.conf /etc/logstash/conf.d/
+	fi
+	if [ "$FREQ_SERVER_ENABLED" = "no" ]; then
+		rm -f /etc/logstash/conf.d/*_postprocess_freq_analysis_*.conf
+	fi
+	if [ "$DOMAIN_STATS_ENABLED" = "yes" ]; then
+		cp -f /etc/logstash/optional/8007_postprocess_dns_top1m_tagging.conf /etc/logstash/conf.d/
+	fi
+	if [ "$DOMAIN_STATS_ENABLED" = "no" ]; then
+		rm -f /etc/logstash/conf.d/8007_postprocess_dns_top1m_tagging.conf
+	fi
 	docker run --name=so-logstash \
 		--detach \
 		--env LS_JAVA_OPTS="-Xms$LOGSTASH_HEAP -Xmx$LOGSTASH_HEAP" \
@@ -85,4 +97,20 @@ if [ "$CURATOR_ENABLED" = "yes" ]; then
                 --volume /etc/curator/action/:/etc/curator/action:ro \
                 --volume /var/log/curator/:/var/log/curator/ \
                 -it $DOCKERHUB/so-curator
+fi
+if [ "$FREQ_SERVER_ENABLED" = "yes" ]; then
+	echo -n "so-freqserver: "
+	docker run --name=so-freqserver \
+		--detach \
+		--publish 10004:10004 \
+		--volume /var/log/freq_server:/var/log/freq_server \
+		lightforge/freq_server
+fi
+if [ "$DOMAIN_STATS_ENABLED" = "yes" ]; then
+	echo -n "so-domainstats: "
+	docker run --name=so-domainstats \
+		--detach \
+		--publish 20000:20000 \
+		--volume /var/log/domain_stats:/var/log/domain_stats \
+		lightforge/domain_stats
 fi


### PR DESCRIPTION
Adds checks for FREQ_SERVER_ENABLED and DOMAIN_STATS_ENABLED. Also, it includes changes to the LOGSTASH_ENABLED section to account for freq_server and domain_stats related configuration files being loaded or not depending on if freq_server or domain_stats are enabled.