### PR TITLE
Updated grok filter to accomodate OSSEC agents using the 'any' keyword

### DIFF
--- a/configfiles/6501_ossec_sysmon.conf
+++ b/configfiles/6501_ossec_sysmon.conf
@@ -12,17 +12,17 @@ filter {
     #mutate { replace => { "type" => "sysmon" } }
     grok {
 #      match => ["message","%{YEAR:year} %{SYSLOGTIMESTAMP:timestamp} %{DATA:location} %{IP:source_ip}->WinEvtLog %{YEAR:year} %{SYSLOGTIMESTAMP:ossec_timestamp} WinEvtLog: Microsoft-Windows-Sysmon/Operational: INFORMATION\(%{INT:sysmon_event_id}\):"]
-    match => ["message", "%{YEAR:year} %{SYSLOGTIMESTAMP:timestamp} %{DATA:location} %{IP:source_ip}->WinEvtLog %{YEAR:year} %{SYSLOGTIMESTAMP:ossec_timestamp} WinEvtLog: Microsoft-Windows-Sysmon/Operational: INFORMATION\(%{INT:event_id}\): %{GREEDYDATA:rest_of_msg}"]
+    match => ["message", "%{YEAR:year} %{SYSLOGTIMESTAMP:timestamp} %{DATA:location} (any|%{IP:source_ip})->WinEvtLog %{YEAR:year} %{SYSLOGTIMESTAMP:ossec_timestamp} WinEvtLog: Microsoft-Windows-Sysmon/Operational: INFORMATION\(%{INT:event_id}\): %{GREEDYDATA:rest_of_msg}"]
     }
     mutate {
       convert => ["event_id", "integer"]
-      remove_field => ["timestamp"]
+      remove_field => ["timestamp"
       remove_field => ["year"]
     }
   }
   if [event_id] == 1 {
     grok {
-      match => ["rest_of_msg", "Microsoft-Windows-Sysmon: SYSTEM: NT AUTHORITY: %{DATA:hostname}: %{DATA:event_type}:  UtcTime: %{DATA:sysmon_timestamp}  ProcessGuid: \{%{DATA:process_guid}\}  ProcessId: %{INT:process_id}  Image: %{DATA:image_path} CommandLine: %{DATA:process_name} %{DATA:process_arguments}  CurrentDirectory: %{DATA:current_directory}  User: %{DATA:user}  LogonGuid: \{%{DATA:logon_guid}\}  LogonId: %{DATA:logon_id}  TerminalSessionId: %{INT:terminal_id}  IntegrityLevel: %{DATA:integrity_level}  Hashes: MD5=%{DATA:md5},SHA256=%{DATA:sha256}  ParentProcessGuid: \{%{DATA:parent_process_guid}\}  ParentProcessId: %{NONNEGINT:parent_process_id}  ParentImage: %{DATA:parent_image_path} ParentCommandLine: %{GREEDYDATA:parent_process_name}", 
+      match => ["rest_of_msg", "Microsoft-Windows-Sysmon: SYSTEM: NT AUTHORITY: %{DATA:hostname}: %{DATA:event_type}:  UtcTime: %{DATA:sysmon_timestamp}  ProcessGuid: \{%{DATA:process_guid}\}  ProcessId: %{INT:process_id}  Image: %{DATA:image_path} CommandLine: %{DATA:process_name} %{DATA:process_arguments}  CurrentDirectory: %{DATA:current_directory}  User: %{DATA:user}  LogonGuid: \{%{DATA:logon_guid}\}  LogonId: %{DATA:logon_id}  TerminalSessionId: %{INT:terminal_id}  IntegrityLevel: %{DATA:integrity_level}  Hashes: MD5=%{DATA:md5},SHA256=%{DATA:sha256}  ParentProcessGuid: \{%{DATA:parent_process_guid}\}  ParentProcessId: %{NONNEGINT:parent_process_id}  ParentImage: %{DATA:parent_image_path} ParentCommandLine: %{GREEDYDATA:parent_process_name}",
 		"rest_of_msg", 'Microsoft-Windows-Sysmon: SYSTEM: NT AUTHORITY: %{DATA:hostname}: %{DATA:event_type}:  UtcTime: %{DATA:sysmon_timestamp}  ProcessGuid: \{%{DATA:process_guid}\}  ProcessId: %{INT:process_id}  Image: %{DATA:image_path} CommandLine: "%{DATA:process_name}" %{DATA:process_arguments}  CurrentDirectory: %{DATA:current_directory}  User: %{DATA:user}  LogonGuid: \{%{DATA:logon_guid}\}  LogonId: %{DATA:logon_id}  TerminalSessionId: %{INT:terminal_id}  IntegrityLevel:%{DATA:integrity_level}']
     }
     mutate {
@@ -78,4 +78,3 @@ filter {
 #    }
 #  }
 }
-


### PR DESCRIPTION
In a deployment where OSSEC agents and OSSEC server reside on different networks separated by a NAT device, OSSEC agents may be assigned the address 'any' instead of a specific IP address. 

The current OSSEC grok filter assumes an IP address is present in the log data forwarded by OSSEC agents, this is not always the case.

This commit updates the grok filter used to accept either the 'any' keyword or an IP address.